### PR TITLE
Enabled accessing internal IPs for covers and custom metadata

### DIFF
--- a/audiobookshelfserver/config.yaml
+++ b/audiobookshelfserver/config.yaml
@@ -15,6 +15,7 @@ options:
   TZ: America/Los_Angeles
   ACCESS_TOKEN_EXPIRY: 43200
   REFRESH_TOKEN_EXPIRY: 604800
+  DISABLE_SSRF_REQUEST_FILTER: 0
 schema:
   CONFIG_PATH: str
   METADATA_PATH: str
@@ -24,6 +25,7 @@ schema:
   TZ: str
   ACCESS_TOKEN_EXPIRY: int
   REFRESH_TOKEN_EXPIRY: int
+  DISABLE_SSRF_REQUEST_FILTER: bool
 ports:
   80/tcp: 13379
 ports_description:

--- a/audiobookshelfserver/run.sh
+++ b/audiobookshelfserver/run.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bashio
 
+if bashio::config.true 'DISABLE_SSRF_REQUEST_FILTER'; then
+    bashio::log.info "Disabling SSRF request filter..."
+    export DISABLE_SSRF_REQUEST_FILTER=1
+fi
+
 exec /usr/bin/audiobookshelf


### PR DESCRIPTION
I've set up a custom, internal metadata server to provide matches for known files in Audiobookshelf.  But, it balks at being able to grab their covers because of SSRF filters.  I believe this will non-invasively enable me to use my internal metadata server.

Thanks for creating this add-on -- I love it and it's working great.
